### PR TITLE
feat: revert to 'old' production deployment

### DIFF
--- a/environments/production/environment.yaml
+++ b/environments/production/environment.yaml
@@ -6,7 +6,7 @@ app:
   # Set the build version ID to deploy for the "Build, deploy, and run" 
   # scenario. If the value is set to an empty string ("") the application
   # is not deployed.
-  version: "f445b871-ba0c-478e-9fbb-e8764093d4e5"
+  version: "c87b1deb-01f0-43df-9315-650c05b25e72"
   
   # Set the Maven coordinates of the Maven artifact to deploy for the 
   # "Deploy, and run" scenario.


### PR DESCRIPTION
Supersedes prior production deployment, by downgrading production to the previous source build. Used for investigation of artefact retention.